### PR TITLE
fix: add arn to Outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ providing default values that should make sense for most use cases.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_arn"></a> [arn](#output\_arn) | The cloudwatch log group ARN |
 | <a name="output_name"></a> [name](#output\_name) | The cloudwatch log group name |
 
 ## Providers

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,8 @@
+output "arn" {
+  description = "The cloudwatch log group ARN"
+  value       = aws_cloudwatch_log_group.main.arn
+}
+
 output "name" {
   description = "The cloudwatch log group name"
   value       = aws_cloudwatch_log_group.main.name


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->

## What it solves

Expose ARN of Cloudwatch Log Group

## How this PR fixes it

Add the ARN to the Outputs

## Readiness Checklist

### Author/Contributor
- [ ] If documentation is needed for this change, has that been included in this pull request
- [ ] Pull request title is brief and descriptive (for a changelog entry)

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, or `enhancement`
- [ ] Label as `bump:patch`, `bump:minor`, or `bump:major` if this PR should create a new release
